### PR TITLE
Fix tests by replacing ESM modules

### DIFF
--- a/app/client/platforms/google.ts
+++ b/app/client/platforms/google.ts
@@ -24,7 +24,7 @@ import {
   isVisionModel,
 } from "@/app/utils";
 import { preProcessImageContent } from "@/app/utils/chat";
-import { nanoid } from "nanoid";
+import { nanoid } from "@/app/utils/nanoid";
 import { RequestPayload } from "./openai";
 import { fetch } from "@/app/utils/stream";
 

--- a/app/client/platforms/tencent.ts
+++ b/app/client/platforms/tencent.ts
@@ -18,10 +18,6 @@ import {
 import { prettyObject } from "@/app/utils/format";
 import { getClientConfig } from "@/app/config/client";
 import { getMessageTextContent, isVisionModel } from "@/app/utils";
-import mapKeys from "lodash-es/mapKeys";
-import mapValues from "lodash-es/mapValues";
-import isArray from "lodash-es/isArray";
-import isObject from "lodash-es/isObject";
 import { fetch } from "@/app/utils/stream";
 
 export interface OpenAIListModelResponse {
@@ -45,15 +41,17 @@ interface RequestPayload {
 }
 
 function capitalizeKeys(obj: any): any {
-  if (isArray(obj)) {
+  if (Array.isArray(obj)) {
     return obj.map(capitalizeKeys);
-  } else if (isObject(obj)) {
-    return mapValues(
-      mapKeys(obj, (value: any, key: string) =>
-        key.replace(/(^|_)(\w)/g, (m, $1, $2) => $2.toUpperCase()),
-      ),
-      capitalizeKeys,
-    );
+  } else if (obj && typeof obj === "object") {
+    const result: any = {};
+    Object.keys(obj).forEach((key) => {
+      const newKey = key.replace(/(^|_)(\w)/g, (_m, _1, $2) =>
+        $2.toUpperCase(),
+      );
+      result[newKey] = capitalizeKeys((obj as any)[key]);
+    });
+    return result;
   } else {
     return obj;
   }

--- a/app/components/artifacts.tsx
+++ b/app/components/artifacts.tsx
@@ -8,7 +8,7 @@ import {
 } from "react";
 import { useParams } from "react-router";
 import { IconButton } from "./button";
-import { nanoid } from "nanoid";
+import { nanoid } from "../utils/nanoid";
 import ExportIcon from "../icons/share.svg";
 import CopyIcon from "../icons/copy.svg";
 import DownloadIcon from "../icons/download.svg";

--- a/app/components/chat.tsx
+++ b/app/components/chat.tsx
@@ -120,7 +120,6 @@ import { ClientApi, MultimodalContent } from "../client/api";
 import { createTTSPlayer } from "../utils/audio";
 import { MsEdgeTTS, OUTPUT_FORMAT } from "../utils/ms_edge_tts";
 
-import { isEmpty } from "lodash-es";
 import { getModelProvider } from "../utils/model";
 import { RealtimeChat } from "@/app/components/realtime-chat";
 import clsx from "clsx";
@@ -1103,7 +1102,7 @@ function _Chat() {
   };
 
   const doSubmit = (userInput: string) => {
-    if (userInput.trim() === "" && isEmpty(attachImages)) return;
+    if (userInput.trim() === "" && attachImages.length === 0) return;
     const matchCommand = chatCommands.match(userInput);
     if (matchCommand.matched) {
       setUserInput("");

--- a/app/components/model-config.tsx
+++ b/app/components/model-config.tsx
@@ -5,7 +5,6 @@ import Locale from "../locales";
 import { InputRange } from "./input-range";
 import { ListItem, Select } from "./ui-lib";
 import { useAllModels } from "../utils/hooks";
-import { groupBy } from "lodash-es";
 import styles from "./model-config.module.scss";
 import { getModelProvider } from "../utils/model";
 
@@ -14,10 +13,14 @@ export function ModelConfigList(props: {
   updateConfig: (updater: (config: ModelConfig) => void) => void;
 }) {
   const allModels = useAllModels();
-  const groupModels = groupBy(
-    allModels.filter((v) => v.available),
-    "provider.providerName",
-  );
+  const groupModels = allModels
+    .filter((v) => v.available)
+    .reduce<Record<string, typeof allModels>>((acc, v) => {
+      const key = v.provider.providerName;
+      if (!acc[key]) acc[key] = [] as any;
+      (acc[key] as any).push(v);
+      return acc;
+    }, {});
   const value = `${props.modelConfig.model}@${props.modelConfig?.providerName}`;
   const compressModelValue = `${props.modelConfig.compressModel}@${props.modelConfig?.compressProviderName}`;
 

--- a/app/components/settings.tsx
+++ b/app/components/settings.tsx
@@ -83,7 +83,7 @@ import { useNavigate } from "react-router-dom";
 import { Avatar, AvatarPicker } from "./emoji";
 import { getClientConfig } from "../config/client";
 import { useSyncStore } from "../store/sync";
-import { nanoid } from "nanoid";
+import { nanoid } from "../utils/nanoid";
 import { useMaskStore } from "../store/mask";
 import { ProviderType } from "../utils/cloud";
 import { TTSConfigList } from "./tts-config";

--- a/app/mcp/client.ts
+++ b/app/mcp/client.ts
@@ -1,5 +1,4 @@
-import { Client } from "@modelcontextprotocol/sdk/client/index.js";
-import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { MCPClientLogger } from "./logger";
 import { ListToolsResponse, McpRequestMessage, ServerConfig } from "./types";
 import { z } from "zod";
@@ -11,6 +10,11 @@ export async function createClient(
   config: ServerConfig,
 ): Promise<Client> {
   logger.info(`Creating client for ${id}...`);
+
+  const { StdioClientTransport } = await import(
+    "@modelcontextprotocol/sdk/client/stdio.js"
+  );
+  const { Client } = await import("@modelcontextprotocol/sdk/client/index.js");
 
   const transport = new StdioClientTransport({
     command: config.command,

--- a/app/store/chat.ts
+++ b/app/store/chat.ts
@@ -6,7 +6,7 @@ import {
 } from "../utils";
 
 import { indexedDBStorage } from "@/app/utils/indexedDB-storage";
-import { nanoid } from "nanoid";
+import { nanoid } from "../utils/nanoid";
 import type {
   ClientApi,
   MultimodalContent,

--- a/app/store/mask.ts
+++ b/app/store/mask.ts
@@ -3,7 +3,7 @@ import { getLang, Lang } from "../locales";
 import { DEFAULT_TOPIC, ChatMessage } from "./chat";
 import { ModelConfig, useAppConfig } from "./config";
 import { StoreKey } from "../constant";
-import { nanoid } from "nanoid";
+import { nanoid } from "../utils/nanoid";
 import { createPersistStore } from "../utils/store";
 
 export type Mask = {

--- a/app/store/plugin.ts
+++ b/app/store/plugin.ts
@@ -1,6 +1,6 @@
 import OpenAPIClientAxios from "openapi-client-axios";
 import { StoreKey } from "../constant";
-import { nanoid } from "nanoid";
+import { nanoid } from "../utils/nanoid";
 import { createPersistStore } from "../utils/store";
 import { getClientConfig } from "../config/client";
 import yaml from "js-yaml";
@@ -239,8 +239,9 @@ export const usePluginStore = createPersistStore(
       fetch("./plugins.json")
         .then((res) => res.json())
         .then((res) => {
+          const list = Array.isArray(res) ? res : [];
           Promise.all(
-            res.map((item: any) =>
+            list.map((item: any) =>
               // skip get schema
               state.get(item.id)
                 ? item

--- a/app/store/prompt.ts
+++ b/app/store/prompt.ts
@@ -1,5 +1,5 @@
 import Fuse from "fuse.js";
-import { nanoid } from "nanoid";
+import { nanoid } from "../utils/nanoid";
 import { StoreKey } from "../constant";
 import { getLang } from "../locales";
 import { createPersistStore } from "../utils/store";

--- a/app/store/sd.ts
+++ b/app/store/sd.ts
@@ -6,7 +6,7 @@ import {
 } from "@/app/constant";
 import { getBearerToken } from "@/app/client/api";
 import { createPersistStore } from "@/app/utils/store";
-import { nanoid } from "nanoid";
+import { nanoid } from "../utils/nanoid";
 import { uploadImage, base64Image2Blob } from "@/app/utils/chat";
 import { models, getModelParamBasicData } from "@/app/components/sd/sd-panel";
 import { useAccessStore } from "./access";

--- a/app/utils.ts
+++ b/app/utils.ts
@@ -6,7 +6,7 @@ import { ServiceProvider } from "./constant";
 // import { fetch as tauriFetch, ResponseType } from "@tauri-apps/api/http";
 import { fetch as tauriStreamFetch } from "./utils/stream";
 import { VISION_MODEL_REGEXES, EXCLUDE_VISION_MODEL_REGEXES } from "./constant";
-import { useAccessStore } from "./store";
+import { useAccessStore } from "./store/access";
 import { ModelSize } from "./typing";
 
 export function trimTopic(topic: string) {

--- a/app/utils/nanoid.ts
+++ b/app/utils/nanoid.ts
@@ -1,0 +1,12 @@
+export function nanoid(size = 21): string {
+  if (typeof crypto !== "undefined" && "randomUUID" in crypto) {
+    return crypto.randomUUID().replace(/-/g, "").slice(0, size);
+  }
+  const chars =
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+  let id = "";
+  for (let i = 0; i < size; i++) {
+    id += chars[Math.floor(Math.random() * chars.length)];
+  }
+  return id;
+}

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -15,6 +15,7 @@ const config: Config = {
   moduleNameMapper: {
     "^@/(.*)$": "<rootDir>/$1",
   },
+  transformIgnorePatterns: ["node_modules/(?!(nanoid)/)"],
 };
 
 // createJestConfig is exported this way to ensure that next/jest can load the Next.js config which is async


### PR DESCRIPTION
## Summary
- implement local `nanoid` generator and replace all `nanoid` imports
- convert lodash-es usages to native helpers
- lazy load MCP SDK to avoid ESM parsing
- guard plugin list parsing
- allow Jest to transform `nanoid` package

## Testing
- `yarn test:ci`

------
https://chatgpt.com/codex/tasks/task_e_684e9764fdf48321b7e15f5864a47431