### PR TITLE
Add AWS Bedrock provider

### DIFF
--- a/app/api/[provider]/[...path]/route.ts
+++ b/app/api/[provider]/[...path]/route.ts
@@ -12,6 +12,7 @@ import { handle as stabilityHandler } from "../../stability";
 import { handle as iflytekHandler } from "../../iflytek";
 import { handle as deepseekHandler } from "../../deepseek";
 import { handle as siliconflowHandler } from "../../siliconflow";
+import { handle as bedrockHandler } from "../../bedrock";
 import { handle as xaiHandler } from "../../xai";
 import { handle as chatglmHandler } from "../../glm";
 import { handle as proxyHandler } from "../../proxy";
@@ -50,6 +51,8 @@ async function handle(
       return chatglmHandler(req, { params });
     case ApiPath.SiliconFlow:
       return siliconflowHandler(req, { params });
+    case ApiPath.Bedrock:
+      return bedrockHandler(req, { params });
     case ApiPath.OpenAI:
       return openaiHandler(req, { params });
     default:

--- a/app/api/bedrock.ts
+++ b/app/api/bedrock.ts
@@ -1,0 +1,139 @@
+import { getServerSideConfig } from "@/app/config/server";
+import {
+  BEDROCK_BASE_URL,
+  ApiPath,
+  ModelProvider,
+  ServiceProvider,
+} from "@/app/constant";
+import { prettyObject } from "@/app/utils/format";
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@/app/api/auth";
+import { isModelNotavailableInServer } from "@/app/utils/model";
+import aws4 from "aws4";
+
+const serverConfig = getServerSideConfig();
+
+export async function handle(
+  req: NextRequest,
+  { params }: { params: { path: string[] } },
+) {
+  console.log("[Bedrock Route] params ", params);
+
+  if (req.method === "OPTIONS") {
+    return NextResponse.json({ body: "OK" }, { status: 200 });
+  }
+
+  const authResult = auth(req, ModelProvider.Claude);
+  if (authResult.error) {
+    return NextResponse.json(authResult, {
+      status: 401,
+    });
+  }
+
+  try {
+    const response = await request(req);
+    return response;
+  } catch (e) {
+    console.error("[Bedrock] ", e);
+    return NextResponse.json(prettyObject(e));
+  }
+}
+
+async function request(req: NextRequest) {
+  const controller = new AbortController();
+
+  let path = `${req.nextUrl.pathname}`.replaceAll(ApiPath.Bedrock, "");
+
+  let baseUrl = serverConfig.bedrockUrl || BEDROCK_BASE_URL;
+
+  if (!baseUrl.startsWith("http")) {
+    baseUrl = `https://${baseUrl}`;
+  }
+
+  if (baseUrl.endsWith("/")) {
+    baseUrl = baseUrl.slice(0, -1);
+  }
+
+  console.log("[Proxy] ", path);
+  console.log("[Base Url]", baseUrl);
+
+  const timeoutId = setTimeout(
+    () => {
+      controller.abort();
+    },
+    10 * 60 * 1000,
+  );
+
+  const fetchUrl = `${baseUrl}${path}`;
+
+  const unsignedOptions: aws4.Request = {
+    host: fetchUrl.split("//")[1],
+    path: `/${path}`,
+    service: "bedrock",
+    region: serverConfig.bedrockRegion,
+    method: req.method,
+    body: req.body ? await req.text() : undefined,
+    headers: {
+      "Content-Type": "application/json",
+    },
+  } as any;
+
+  aws4.sign(unsignedOptions, {
+    accessKeyId: serverConfig.bedrockAccessKeyId || "",
+    secretAccessKey: serverConfig.bedrockSecretAccessKey || "",
+    sessionToken: serverConfig.bedrockSessionToken || undefined,
+  });
+
+  const fetchOptions: RequestInit = {
+    method: unsignedOptions.method,
+    body: unsignedOptions.body,
+    headers: unsignedOptions.headers as any,
+    redirect: "manual",
+    // @ts-ignore
+    duplex: "half",
+    signal: controller.signal,
+  };
+
+  if (serverConfig.customModels && fetchOptions.body) {
+    try {
+      const jsonBody = JSON.parse(fetchOptions.body as string) as {
+        model?: string;
+      };
+
+      if (
+        isModelNotavailableInServer(
+          serverConfig.customModels,
+          jsonBody?.model as string,
+          ServiceProvider.Bedrock as string,
+        )
+      ) {
+        return NextResponse.json(
+          {
+            error: true,
+            message: `you are not allowed to use ${jsonBody?.model} model`,
+          },
+          {
+            status: 403,
+          },
+        );
+      }
+    } catch (e) {
+      console.error(`[Bedrock] filter`, e);
+    }
+  }
+  try {
+    const res = await fetch(fetchUrl, fetchOptions);
+
+    const newHeaders = new Headers(res.headers);
+    newHeaders.delete("www-authenticate");
+    newHeaders.set("X-Accel-Buffering", "no");
+
+    return new Response(res.body, {
+      status: res.status,
+      statusText: res.statusText,
+      headers: newHeaders,
+    });
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}

--- a/app/client/api.ts
+++ b/app/client/api.ts
@@ -24,6 +24,7 @@ import { DeepSeekApi } from "./platforms/deepseek";
 import { XAIApi } from "./platforms/xai";
 import { ChatGLMApi } from "./platforms/glm";
 import { SiliconflowApi } from "./platforms/siliconflow";
+import { BedrockApi } from "./platforms/bedrock";
 
 export const ROLES = ["system", "user", "assistant"] as const;
 export type MessageRole = (typeof ROLES)[number];
@@ -168,6 +169,9 @@ export class ClientApi {
       case ModelProvider.SiliconFlow:
         this.llm = new SiliconflowApi();
         break;
+      case ModelProvider.Bedrock:
+        this.llm = new BedrockApi();
+        break;
       default:
         this.llm = new ChatGPTApi();
     }
@@ -260,6 +264,7 @@ export function getHeaders(ignoreHeaders: boolean = false) {
     const isChatGLM = modelConfig.providerName === ServiceProvider.ChatGLM;
     const isSiliconFlow =
       modelConfig.providerName === ServiceProvider.SiliconFlow;
+    const isBedrock = modelConfig.providerName === ServiceProvider.Bedrock;
     const isEnabledAccessControl = accessStore.enabledAccessControl();
     const apiKey = isGoogle
       ? accessStore.googleApiKey
@@ -281,6 +286,8 @@ export function getHeaders(ignoreHeaders: boolean = false) {
       ? accessStore.chatglmApiKey
       : isSiliconFlow
       ? accessStore.siliconflowApiKey
+      : isBedrock
+      ? accessStore.bedrockAccessKeyId
       : isIflytek
       ? accessStore.iflytekApiKey && accessStore.iflytekApiSecret
         ? accessStore.iflytekApiKey + ":" + accessStore.iflytekApiSecret
@@ -299,6 +306,7 @@ export function getHeaders(ignoreHeaders: boolean = false) {
       isXAI,
       isChatGLM,
       isSiliconFlow,
+      isBedrock,
       apiKey,
       isEnabledAccessControl,
     };
@@ -327,6 +335,7 @@ export function getHeaders(ignoreHeaders: boolean = false) {
     isXAI,
     isChatGLM,
     isSiliconFlow,
+    isBedrock,
     apiKey,
     isEnabledAccessControl,
   } = getConfig();
@@ -377,6 +386,8 @@ export function getClientApi(provider: ServiceProvider): ClientApi {
       return new ClientApi(ModelProvider.ChatGLM);
     case ServiceProvider.SiliconFlow:
       return new ClientApi(ModelProvider.SiliconFlow);
+    case ServiceProvider.Bedrock:
+      return new ClientApi(ModelProvider.Bedrock);
     default:
       return new ClientApi(ModelProvider.GPT);
   }

--- a/app/client/platforms/bedrock.ts
+++ b/app/client/platforms/bedrock.ts
@@ -1,0 +1,133 @@
+"use client";
+
+import {
+  ApiPath,
+  BEDROCK_BASE_URL,
+  Bedrock,
+  REQUEST_TIMEOUT_MS,
+} from "@/app/constant";
+import {
+  ChatOptions,
+  getHeaders,
+  LLMApi,
+  LLMModel,
+  SpeechOptions,
+} from "../api";
+import { useAccessStore, useAppConfig, useChatStore } from "@/app/store";
+import { stream } from "@/app/utils/chat";
+import { fetch } from "@/app/utils/stream";
+import { getClientConfig } from "@/app/config/client";
+import { getMessageTextContent } from "@/app/utils";
+
+export class BedrockApi implements LLMApi {
+  private disableListModels = true;
+
+  path(path: string): string {
+    const accessStore = useAccessStore.getState();
+
+    let baseUrl = "";
+    if (accessStore.useCustomConfig) {
+      baseUrl = accessStore.bedrockUrl;
+    }
+
+    if (baseUrl.length === 0) {
+      const isApp = !!getClientConfig()?.isApp;
+      baseUrl = isApp ? BEDROCK_BASE_URL : ApiPath.Bedrock;
+    }
+
+    if (baseUrl.endsWith("/")) {
+      baseUrl = baseUrl.slice(0, baseUrl.length - 1);
+    }
+    if (!baseUrl.startsWith("http") && !baseUrl.startsWith(ApiPath.Bedrock)) {
+      baseUrl = "https://" + baseUrl;
+    }
+
+    return [baseUrl, path].join("/");
+  }
+
+  speech(options: SpeechOptions): Promise<ArrayBuffer> {
+    throw new Error("Method not implemented.");
+  }
+
+  extractMessage(res: any) {
+    return res?.content?.[0]?.text;
+  }
+
+  async chat(options: ChatOptions): Promise<void> {
+    const messages: ChatOptions["messages"] = [];
+    for (const v of options.messages) {
+      messages.push({ role: v.role, content: getMessageTextContent(v) });
+    }
+
+    const modelConfig = {
+      ...useAppConfig.getState().modelConfig,
+      ...useChatStore.getState().currentSession().mask.modelConfig,
+      ...{
+        model: options.config.model,
+      },
+    };
+
+    const requestPayload = {
+      messages,
+      stream: options.config.stream,
+      model: modelConfig.model,
+      max_tokens: modelConfig.max_tokens,
+      temperature: modelConfig.temperature,
+      top_p: modelConfig.top_p,
+    };
+
+    const shouldStream = !!options.config.stream;
+    const controller = new AbortController();
+    options.onController?.(controller);
+
+    try {
+      const chatPath = this.path(Bedrock.ChatPath);
+      const chatPayload = {
+        method: "POST",
+        body: JSON.stringify(requestPayload),
+        signal: controller.signal,
+        headers: getHeaders(),
+      };
+
+      const requestTimeoutId = setTimeout(
+        () => controller.abort(),
+        REQUEST_TIMEOUT_MS,
+      );
+
+      if (shouldStream) {
+        await stream(chatPath, chatPayload, {
+          onData: (text, chunk) => {
+            options.onUpdate?.(text, chunk);
+          },
+          onEnd: (text, res) => {
+            options.onFinish(text, res);
+          },
+          onError: (err) => {
+            options.onError?.(err);
+          },
+        });
+      } else {
+        const res = await fetch(chatPath, chatPayload);
+        const resJson = await res.json();
+        const message = this.extractMessage(resJson);
+        options.onFinish(message, res);
+      }
+
+      clearTimeout(requestTimeoutId);
+    } catch (e) {
+      console.error("failed to chat", e);
+      options.onError?.(e as Error);
+    }
+  }
+
+  async usage() {
+    return { used: 0, total: 0 };
+  }
+
+  async models(): Promise<LLMModel[]> {
+    if (this.disableListModels) {
+      return [];
+    }
+    return [];
+  }
+}

--- a/app/components/settings.tsx
+++ b/app/components/settings.tsx
@@ -75,6 +75,7 @@ import {
   ChatGLM,
   DeepSeek,
   SiliconFlow,
+  Bedrock,
 } from "../constant";
 import { Prompt, SearchService, usePromptStore } from "../store/prompt";
 import { ErrorBoundary } from "./error";
@@ -1360,6 +1361,81 @@ export function Settings() {
     </>
   );
 
+  const bedrockConfigComponent = accessStore.provider ===
+    ServiceProvider.Bedrock && (
+    <>
+      <ListItem
+        title={Locale.Settings.Access.Bedrock.Endpoint.Title}
+        subTitle={
+          Locale.Settings.Access.Bedrock.Endpoint.SubTitle +
+          Bedrock.ExampleEndpoint
+        }
+      >
+        <input
+          aria-label={Locale.Settings.Access.Bedrock.Endpoint.Title}
+          type="text"
+          value={accessStore.bedrockUrl}
+          placeholder={Bedrock.ExampleEndpoint}
+          onChange={(e) =>
+            accessStore.update(
+              (access) => (access.bedrockUrl = e.currentTarget.value),
+            )
+          }
+        ></input>
+      </ListItem>
+      <ListItem title="Access Key ID" subTitle="">
+        <PasswordInput
+          aria-label="Access Key ID"
+          value={accessStore.bedrockAccessKeyId}
+          type="text"
+          onChange={(e) => {
+            accessStore.update(
+              (access) => (access.bedrockAccessKeyId = e.currentTarget.value),
+            );
+          }}
+        />
+      </ListItem>
+      <ListItem title="Secret Access Key" subTitle="">
+        <PasswordInput
+          aria-label="Secret Access Key"
+          value={accessStore.bedrockSecretAccessKey}
+          type="text"
+          onChange={(e) => {
+            accessStore.update(
+              (access) =>
+                (access.bedrockSecretAccessKey = e.currentTarget.value),
+            );
+          }}
+        />
+      </ListItem>
+      <ListItem title="Session Token" subTitle="">
+        <PasswordInput
+          aria-label="Session Token"
+          value={accessStore.bedrockSessionToken}
+          type="text"
+          onChange={(e) => {
+            accessStore.update(
+              (access) => (access.bedrockSessionToken = e.currentTarget.value),
+            );
+          }}
+        />
+      </ListItem>
+      <ListItem title="Region" subTitle="">
+        <input
+          aria-label="Region"
+          type="text"
+          value={accessStore.bedrockRegion}
+          placeholder="ap-northeast-1"
+          onChange={(e) =>
+            accessStore.update(
+              (access) => (access.bedrockRegion = e.currentTarget.value),
+            )
+          }
+        />
+      </ListItem>
+    </>
+  );
+
   const stabilityConfigComponent = accessStore.provider ===
     ServiceProvider.Stability && (
     <>
@@ -1822,6 +1898,7 @@ export function Settings() {
                   {XAIConfigComponent}
                   {chatglmConfigComponent}
                   {siliconflowConfigComponent}
+                  {bedrockConfigComponent}
                 </>
               )}
             </>

--- a/app/config/server.ts
+++ b/app/config/server.ts
@@ -88,6 +88,13 @@ declare global {
       SILICONFLOW_URL?: string;
       SILICONFLOW_API_KEY?: string;
 
+      // bedrock only
+      BEDROCK_URL?: string;
+      BEDROCK_ACCESS_KEY_ID?: string;
+      BEDROCK_SECRET_ACCESS_KEY?: string;
+      BEDROCK_SESSION_TOKEN?: string;
+      BEDROCK_REGION?: string;
+
       // custom template for preprocessing user input
       DEFAULT_INPUT_TEMPLATE?: string;
 
@@ -163,6 +170,7 @@ export const getServerSideConfig = () => {
   const isXAI = !!process.env.XAI_API_KEY;
   const isChatGLM = !!process.env.CHATGLM_API_KEY;
   const isSiliconFlow = !!process.env.SILICONFLOW_API_KEY;
+  const isBedrock = !!process.env.BEDROCK_ACCESS_KEY_ID;
   // const apiKeyEnvVar = process.env.OPENAI_API_KEY ?? "";
   // const apiKeys = apiKeyEnvVar.split(",").map((v) => v.trim());
   // const randomIndex = Math.floor(Math.random() * apiKeys.length);
@@ -245,6 +253,13 @@ export const getServerSideConfig = () => {
     isSiliconFlow,
     siliconFlowUrl: process.env.SILICONFLOW_URL,
     siliconFlowApiKey: getApiKey(process.env.SILICONFLOW_API_KEY),
+
+    isBedrock,
+    bedrockUrl: process.env.BEDROCK_URL,
+    bedrockAccessKeyId: process.env.BEDROCK_ACCESS_KEY_ID,
+    bedrockSecretAccessKey: process.env.BEDROCK_SECRET_ACCESS_KEY,
+    bedrockSessionToken: process.env.BEDROCK_SESSION_TOKEN,
+    bedrockRegion: process.env.BEDROCK_REGION,
 
     gtmId: process.env.GTM_ID,
     gaId: process.env.GA_ID || DEFAULT_GA_ID,

--- a/app/constant.ts
+++ b/app/constant.ts
@@ -36,6 +36,8 @@ export const CHATGLM_BASE_URL = "https://open.bigmodel.cn";
 
 export const SILICONFLOW_BASE_URL = "https://api.siliconflow.cn";
 
+export const BEDROCK_BASE_URL = "https://bedrock-runtime.amazonaws.com";
+
 export const CACHE_URL_PREFIX = "/api/cache";
 export const UPLOAD_URL = `${CACHE_URL_PREFIX}/upload`;
 
@@ -72,6 +74,7 @@ export enum ApiPath {
   ChatGLM = "/api/chatglm",
   DeepSeek = "/api/deepseek",
   SiliconFlow = "/api/siliconflow",
+  Bedrock = "/api/bedrock",
 }
 
 export enum SlotID {
@@ -129,6 +132,7 @@ export enum ServiceProvider {
   ChatGLM = "ChatGLM",
   DeepSeek = "DeepSeek",
   SiliconFlow = "SiliconFlow",
+  Bedrock = "Bedrock",
 }
 
 // Google API safety settings, see https://ai.google.dev/gemini-api/docs/safety-settings
@@ -155,6 +159,7 @@ export enum ModelProvider {
   ChatGLM = "ChatGLM",
   DeepSeek = "DeepSeek",
   SiliconFlow = "SiliconFlow",
+  Bedrock = "Bedrock",
 }
 
 export const Stability = {
@@ -257,6 +262,11 @@ export const ChatGLM = {
 export const SiliconFlow = {
   ExampleEndpoint: SILICONFLOW_BASE_URL,
   ChatPath: "v1/chat/completions",
+};
+
+export const Bedrock = {
+  ExampleEndpoint: BEDROCK_BASE_URL,
+  ChatPath: "model/anthropic.chat-completions",
 };
 
 export const DEFAULT_INPUT_TEMPLATE = `{{input}}`; // input / time / model / lang
@@ -622,6 +632,8 @@ const siliconflowModels = [
   "THUDM/glm-4-9b-chat",
 ];
 
+const bedrockModels = anthropicModels;
+
 let seq = 1000; // 内置的模型序号生成器从1000开始
 export const DEFAULT_MODELS = [
   ...openaiModels.map((name) => ({
@@ -776,6 +788,17 @@ export const DEFAULT_MODELS = [
       providerName: "SiliconFlow",
       providerType: "siliconflow",
       sorted: 14,
+    },
+  })),
+  ...bedrockModels.map((name) => ({
+    name,
+    available: true,
+    sorted: seq++,
+    provider: {
+      id: "bedrock",
+      providerName: "Bedrock",
+      providerType: "bedrock",
+      sorted: 15,
     },
   })),
 ] as const;

--- a/app/locales/cn.ts
+++ b/app/locales/cn.ts
@@ -507,6 +507,17 @@ const cn = {
           SubTitle: "样例：",
         },
       },
+      Bedrock: {
+        Endpoint: {
+          Title: "接口地址",
+          SubTitle: "样例：",
+        },
+        ApiKey: {
+          Title: "访问密钥 ID",
+          SubTitle: "使用你的 AWS Access Key",
+          Placeholder: "Access Key ID",
+        },
+      },
       Stability: {
         ApiKey: {
           Title: "接口密钥",

--- a/app/locales/en.ts
+++ b/app/locales/en.ts
@@ -491,6 +491,17 @@ const en: LocaleType = {
           SubTitle: "Example: ",
         },
       },
+      Bedrock: {
+        Endpoint: {
+          Title: "Endpoint Address",
+          SubTitle: "Example: ",
+        },
+        ApiKey: {
+          Title: "Access Key ID",
+          SubTitle: "Use your AWS access key",
+          Placeholder: "Access Key ID",
+        },
+      },
       Stability: {
         ApiKey: {
           Title: "Stability API Key",

--- a/app/store/access.ts
+++ b/app/store/access.ts
@@ -17,6 +17,7 @@ import {
   XAI_BASE_URL,
   CHATGLM_BASE_URL,
   SILICONFLOW_BASE_URL,
+  BEDROCK_BASE_URL,
 } from "../constant";
 import { getHeaders } from "../client/api";
 import { getClientConfig } from "../config/client";
@@ -58,6 +59,8 @@ const DEFAULT_CHATGLM_URL = isApp ? CHATGLM_BASE_URL : ApiPath.ChatGLM;
 const DEFAULT_SILICONFLOW_URL = isApp
   ? SILICONFLOW_BASE_URL
   : ApiPath.SiliconFlow;
+
+const DEFAULT_BEDROCK_URL = isApp ? BEDROCK_BASE_URL : ApiPath.Bedrock;
 
 const DEFAULT_ACCESS_STATE = {
   accessCode: "",
@@ -131,6 +134,13 @@ const DEFAULT_ACCESS_STATE = {
   // siliconflow
   siliconflowUrl: DEFAULT_SILICONFLOW_URL,
   siliconflowApiKey: "",
+
+  // bedrock
+  bedrockUrl: DEFAULT_BEDROCK_URL,
+  bedrockAccessKeyId: "",
+  bedrockSecretAccessKey: "",
+  bedrockSessionToken: "",
+  bedrockRegion: "",
 
   // server config
   needCode: true,
@@ -219,6 +229,14 @@ export const useAccessStore = createPersistStore(
       return ensure(get(), ["siliconflowApiKey"]);
     },
 
+    isValidBedrock() {
+      return ensure(get(), [
+        "bedrockAccessKeyId",
+        "bedrockSecretAccessKey",
+        "bedrockRegion",
+      ]);
+    },
+
     isAuthorized() {
       this.fetch();
 
@@ -238,6 +256,7 @@ export const useAccessStore = createPersistStore(
         this.isValidXAI() ||
         this.isValidChatGLM() ||
         this.isValidSiliconFlow() ||
+        this.isValidBedrock() ||
         !this.enabledAccessControl() ||
         (this.enabledAccessControl() && ensure(get(), ["accessCode"]))
       );

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@svgr/webpack": "^6.5.1",
     "@vercel/analytics": "^0.1.11",
     "@vercel/speed-insights": "^1.0.2",
+    "aws4": "^1.13.2",
     "axios": "^1.7.5",
     "clsx": "^2.1.1",
     "emoji-picker-react": "^4.9.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2854,6 +2854,11 @@ available-typed-arrays@^1.0.5:
   resolved "https://registry.yarnpkg.com/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz#92f95616501069d07d10edb2fc37d3e1c65123b7"
   integrity sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==
 
+aws4@^1.13.2:
+  version "1.13.2"
+  resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.13.2.tgz#0aa167216965ac9474ccfa83892cfb6b3e1e52ef"
+  integrity sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw==
+
 axe-core@^4.6.2:
   version "4.6.3"
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.6.3.tgz#fc0db6fdb65cc7a80ccf85286d91d64ababa3ece"


### PR DESCRIPTION
## Summary
- add Bedrock API server route and client platform
- support Bedrock provider in constants and config
- expose Bedrock settings in UI and locales
- include aws4 dependency for request signing

## Testing
- `yarn lint`
- `yarn test:ci`


------
https://chatgpt.com/codex/tasks/task_e_684eae7d4bc883218af01dd2150da2ba